### PR TITLE
Refactor RFAI into modular orchestrator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Lint
+        run: |
+          black --check src tests install.py
+          flake8 src tests install.py
+          mypy src
+      - name: Test
+        run: pytest -v
+      - name: Docker build
+        run: docker build -t rfai-system .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        args: ["--line-length", "88"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: ["flake8-bugbear"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: ["pydantic>=2.5"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Recursive Fractal Mind
+
+Thank you for your interest in improving the RFAI system! This guide outlines
+the workflow used in this repository.
+
+## Branching and Pull Requests
+
+1. Create feature branches from `work` using descriptive names, e.g.
+   `feature/add-swarm-simulation`.
+2. Keep commits small and focused. Squash commits only when necessary to clean
+   up the history before merging.
+3. Open a pull request against `work` and fill out the PR template. Describe the
+   motivation, implementation, and testing performed.
+4. Request at least one review before merging. Address review comments promptly.
+
+## Code Style
+
+- Target Python 3.11+ and follow PEP 8.
+- Use type hints everywhere. Run `mypy` locally before submitting a pull request.
+- Format code with `black` (line length 88) and lint with `flake8`.
+- Avoid global state. Use dependency injection to pass configuration.
+- Log actionable information with the `logging` module instead of `print`.
+
+## Testing
+
+- Add unit tests for all new features or bug fixes.
+- Run `pytest -v` before submitting a PR.
+- Integration changes that affect the API must include FastAPI `TestClient`
+  coverage.
+
+## Tooling
+
+Install developer tooling via:
+
+```bash
+python install.py --dev --verify
+```
+
+This installs dependencies and runs the test suite to verify the environment.
+
+## Release Process
+
+1. Ensure the CI workflow passes on the main branch.
+2. Build and tag a Docker image: `docker build -t rfai-system:<tag> .`.
+3. Push Kubernetes manifests updates as needed.
+4. Create a release note summarizing major changes and deployment steps.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+COPY install.py ./
+
+ENV API_KEY=""
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,99 @@
-# Recursive Fractal Intelligence Models (RFIM)
+# Recursive Fractal Mind (RFAI)
 
-An evolving architecture of adaptive recursive AI systems inspired by fractal structures, quantum cognition, and self-referential meta-learning.
+Recursive Fractal Mind (RFAI) is a modular orchestration framework that models
+recursive intelligence through coordinated subsystems. The orchestrator exposes
+an HTTP API that combines the Fractal Engine, Swarm Coordinator, Quantum
+Processor, and Meta Learner to process numeric task payloads.
 
-## Core Components
-- **AMIFS** – Adaptive Multiscale Iterated Function Systems
-- **DFE** – Dynamic Fractal Encoding
-- **RSA** – Recursive Structural Adaptation
-- **Semantic Nodes** – Goal-oriented symbolic agents
+## Architecture Overview
+
+```
+[Client]
+   |
+   v
+[FastAPI Service] -- Auth --> [RFAISystem Orchestrator]
+                                   |
+                                   +--> Fractal Engine (recursive signal transform)
+                                   +--> Swarm Coordinator (agent consensus)
+                                   +--> Quantum Processor (probabilistic synthesis)
+                                   +--> Meta Learner (adaptive insights)
+```
+
+Each subsystem can be swapped or disabled at runtime. Configuration is validated
+with Pydantic models to ensure safe defaults.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python install.py --dev
+```
+
+The `--dev` flag upgrades dependencies suitable for local development. Use
+`python install.py --verify` to run the automated test suite after installing
+requirements.
+
+## Usage
+
+### Running the API
+
+```bash
+export API_KEY=changeme
+uvicorn src.api:app --reload
+```
+
+### Processing a Task
+
+```bash
+curl -X POST \
+  -H "X-API-Key: changeme" \
+  -H "Content-Type: application/json" \
+  -d '{"values": [1, 2, 3, 4]}' \
+  http://127.0.0.1:8000/process_task
+```
+
+### Status and Health
+
+- `GET /health` – service heartbeat
+- `GET /status` – orchestrator status (requires API key)
+
+## Testing
+
+```bash
+pytest -v
+```
+
+## State Persistence
+
+Use `src.utils.state_manager.save_state` and `load_state` to persist orchestrator
+state with checksum validation.
+
+## Docker
+
+```bash
+docker build -t rfai-system .
+docker run -e API_KEY=changeme -p 8000:8000 rfai-system
+```
+
+## Kubernetes
+
+Deploy manifests from `deploy/k8s/` after pushing the container image to your
+registry. The deployment includes liveness and readiness probes hitting
+`/health`.
+
+## Project Layout
+
+- `src/rfai_system.py` – orchestrator
+- `src/fractal_engine/` – fractal processing subsystem
+- `src/swarm_coordinator/` – swarm intelligence layer
+- `src/quantum_processor/` – quantum-classical processor stub
+- `src/meta_learner/` – adaptive meta-learning component
+- `src/api.py` – FastAPI surface
+- `tests/` – pytest suite covering subsystems, persistence, and API
+- `deploy/k8s/` – Kubernetes deployment assets
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on development workflow,
+code style, and pull request expectations.

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rfai-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: rfai-api
+  template:
+    metadata:
+      labels:
+        app: rfai-api
+    spec:
+      containers:
+        - name: rfai-api
+          image: rfai-system:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rfai-secrets
+                  key: api-key
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rfai-api
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - host: rfai.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rfai-api
+                port:
+                  number: 80

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rfai-api
+spec:
+  selector:
+    app: rfai-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  rfai-api:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      API_KEY: ${API_KEY:-changeme}
+    restart: unless-stopped

--- a/install.py
+++ b/install.py
@@ -1,0 +1,54 @@
+"""Installer utility for the RFAI system."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(command: list[str]) -> None:
+    """Run a subprocess command with error propagation."""
+
+    result = subprocess.run(command, check=False)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def install_requirements(dev: bool = False) -> None:
+    requirements = Path("requirements.txt")
+    if not requirements.exists():
+        raise SystemExit("requirements.txt not found")
+
+    command = [sys.executable, "-m", "pip", "install", "-r", str(requirements)]
+    if dev:
+        command.append("--upgrade")
+    run_command(command)
+
+
+def verify_installation() -> None:
+    run_command([sys.executable, "-m", "pytest", "-q"])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Install and verify the RFAI system")
+    parser.add_argument("--verify", action="store_true", help="Run the test suite after installation")
+    parser.add_argument(
+        "--noninteractive",
+        action="store_true",
+        help="Skip interactive prompts (reserved for future use)",
+    )
+    parser.add_argument("--dev", action="store_true", help="Install developer dependencies")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    install_requirements(dev=args.dev)
+    if args.verify:
+        verify_installation()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-numpy>=1.20.0
-scipy>=1.7.0
-matplotlib>=3.4.0
-pytest>=6.0.0
-pytest-cov>=2.12.0
-jsonschema==4.23.0
+fastapi>=0.110
+uvicorn[standard]>=0.29
+pydantic>=2.5
+pytest>=7.4
+mypy>=1.8
+black>=24.3
+flake8>=7.0
+httpx>=0.26

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""RFAI modular orchestration framework."""
+
+from .rfai_system import RFAISystem
+
+__all__ = ["RFAISystem"]

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,65 @@
+"""FastAPI entrypoint for the RFAI orchestrator."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import APIKeyHeader
+
+from .rfai_system import RFAISystem
+
+app = FastAPI(title="Recursive Fractal Mind", version="1.0.0")
+_system = RFAISystem()
+
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+def _expected_api_key() -> str:
+    return os.getenv("API_KEY", "")
+
+
+def get_system() -> RFAISystem:
+    """Expose the orchestrator instance for dependency injection and tests."""
+
+    return _system
+
+
+async def verify_api_key(api_key: str = Depends(api_key_header)) -> str:
+    expected = _expected_api_key()
+    if not expected:
+        return api_key or ""
+    if api_key == expected:
+        return api_key
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing API key"
+    )
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    """Service liveness probe."""
+
+    return {"status": "ok"}
+
+
+@app.get("/status")
+async def status_endpoint(_: str = Depends(verify_api_key)) -> Dict[str, Any]:
+    """Return orchestrator status information."""
+
+    return get_system().get_status()
+
+
+@app.post("/process_task")
+async def process_task(
+    payload: Dict[str, Any],
+    _: str = Depends(verify_api_key),
+) -> Dict[str, Any]:
+    """Trigger a full orchestration cycle."""
+
+    system = get_system()
+    return system.run_cycle(payload)
+
+
+__all__ = ["app", "get_system"]

--- a/src/fractal_engine/__init__.py
+++ b/src/fractal_engine/__init__.py
@@ -1,0 +1,5 @@
+"""Fractal engine package exposing the `FractalEngine` component."""
+
+from .engine import FractalEngine
+
+__all__ = ["FractalEngine"]

--- a/src/fractal_engine/engine.py
+++ b/src/fractal_engine/engine.py
@@ -1,0 +1,53 @@
+"""Implementation of the fractal processing engine."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from ..utils.validation import FractalEngineConfig, ValidationError, validate_input_payload
+
+logger = logging.getLogger(__name__)
+
+
+class FractalEngine:
+    """Apply a recursive fractal transform to numeric sequences.
+
+    The engine contracts each iteration towards the mean of the previous
+    sequence, creating a stabilising fractal pattern.
+    """
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        try:
+            self.config = FractalEngineConfig(**(config or {}))
+        except ValidationError as exc:  # pragma: no cover - pydantic already tested elsewhere
+            logger.error("Invalid fractal engine configuration: %s", exc)
+            raise ValueError("Invalid fractal engine configuration") from exc
+
+    def process(self, input_data: Any) -> Dict[str, Any]:
+        """Run the fractal transformation pipeline."""
+
+        values = validate_input_payload(input_data)
+        depth = min(self.config.max_depth, self.config.recursion_limit)
+        logger.debug("Running fractal transform for %s iterations", depth)
+
+        history: List[List[float]] = []
+        current = values
+        for iteration in range(depth):
+            mean = sum(current) / len(current)
+            transformed = [
+                mean + (value - mean) * self.config.scale_factor for value in current
+            ]
+            logger.debug("Iteration %s produced values: %s", iteration, transformed)
+            history.append(transformed)
+            current = transformed
+
+        return {
+            "initial": values,
+            "history": history,
+            "iterations": depth,
+            "final": current,
+        }
+
+
+__all__ = ["FractalEngine"]

--- a/src/meta_learner/__init__.py
+++ b/src/meta_learner/__init__.py
@@ -1,0 +1,5 @@
+"""Meta learner package exposing the `MetaLearner` component."""
+
+from .meta import MetaLearner
+
+__all__ = ["MetaLearner"]

--- a/src/meta_learner/meta.py
+++ b/src/meta_learner/meta.py
@@ -1,0 +1,62 @@
+"""Meta learning subsystem."""
+
+from __future__ import annotations
+
+import logging
+from statistics import mean
+from typing import Any, Dict
+
+from ..utils.validation import MetaLearnerConfig, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class MetaLearner:
+    """Synthesize a holistic view of orchestrator outputs."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        try:
+            self.config = MetaLearnerConfig(**(config or {}))
+        except ValidationError as exc:  # pragma: no cover - pydantic validation is exercised elsewhere
+            logger.error("Invalid meta learner configuration: %s", exc)
+            raise ValueError("Invalid meta learner configuration") from exc
+
+    def process(self, payload: Any) -> Dict[str, Any]:
+        """Produce adaptive insights from all component outputs."""
+
+        if not isinstance(payload, dict):
+            logger.warning("Meta learner received unexpected payload: %s", payload)
+            return {"score": 0.0, "recommendations": []}
+
+        scores = []
+        if (fractal := payload.get("fractal_output")) and isinstance(fractal, dict):
+            final = fractal.get("final") or []
+            if final:
+                scores.append(mean(final))
+        if (swarm := payload.get("swarm_output")) and isinstance(swarm, dict):
+            if (confidence := swarm.get("confidence")) is not None:
+                scores.append(float(confidence))
+        if (quantum := payload.get("quantum_output")) and isinstance(quantum, dict):
+            if (stability := quantum.get("stability")) is not None:
+                scores.append(float(stability))
+
+        if not scores:
+            return {"score": 0.0, "recommendations": ["Collect more data"]}
+
+        aggregate_score = mean(scores)
+        adjusted_score = aggregate_score * (1 + self.config.momentum * self.config.learning_rate)
+
+        recommendations = [
+            "Maintain current strategy" if adjusted_score >= 0.5 else "Increase exploration",
+            "Monitor confidence" if payload.get("swarm_output", {}).get("confidence", 0) < 0.5 else "Leverage consensus",
+        ]
+
+        logger.debug("Meta learner score %.3f", adjusted_score)
+
+        return {
+            "score": min(1.0, max(0.0, adjusted_score)),
+            "recommendations": recommendations,
+        }
+
+
+__all__ = ["MetaLearner"]

--- a/src/quantum_processor/__init__.py
+++ b/src/quantum_processor/__init__.py
@@ -1,0 +1,5 @@
+"""Quantum processor package exposing the `QuantumProcessor` component."""
+
+from .processor import QuantumProcessor
+
+__all__ = ["QuantumProcessor"]

--- a/src/quantum_processor/processor.py
+++ b/src/quantum_processor/processor.py
@@ -1,0 +1,59 @@
+"""Quantum processor subsystem."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, List
+
+from ..utils.validation import QuantumProcessorConfig, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class QuantumProcessor:
+    """Simulate a lightweight quantum-classical hybrid processor."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        try:
+            self.config = QuantumProcessorConfig(**(config or {}))
+        except ValidationError as exc:  # pragma: no cover - pydantic validation is exercised elsewhere
+            logger.error("Invalid quantum processor configuration: %s", exc)
+            raise ValueError("Invalid quantum processor configuration") from exc
+
+    def process(self, payload: Any) -> Dict[str, Any]:
+        """Generate a probabilistic response from prior component outputs."""
+
+        if not isinstance(payload, dict):
+            logger.warning("Quantum processor received unexpected payload: %s", payload)
+            return {"entangled_state": [], "stability": 0.0}
+
+        fractal_values: List[float] = [
+            float(value)
+            for value in payload.get("fractal_output", {}).get("final", [])
+        ]
+        if not fractal_values:
+            return {"entangled_state": [], "stability": 0.0}
+
+        # Compress the classical signal into a pseudo quantum amplitude distribution.
+        amplitudes = [math.tanh(value / (idx + 1)) for idx, value in enumerate(fractal_values)]
+        norm = math.sqrt(sum(value * value for value in amplitudes)) or 1.0
+        entangled_state = [value / norm for value in amplitudes]
+
+        avg_amplitude = sum(entangled_state) / len(entangled_state)
+        stability = max(0.0, min(1.0, 1 - self.config.decoherence - abs(avg_amplitude)))
+
+        logger.debug(
+            "Quantum processor generated stability %.3f with %s shots",
+            stability,
+            self.config.shots,
+        )
+
+        return {
+            "entangled_state": entangled_state,
+            "stability": stability,
+            "shots": self.config.shots,
+        }
+
+
+__all__ = ["QuantumProcessor"]

--- a/src/rfai_system.py
+++ b/src/rfai_system.py
@@ -1,0 +1,166 @@
+"""Orchestrator for the Recursive Fractal Autonomous Intelligence system."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Mapping, MutableMapping, Optional
+
+from .utils.validation import (
+    ValidationError,
+    validate_component_config,
+    validate_input_payload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ComponentSpec:
+    """Metadata describing how to load a component."""
+
+    module_path: str
+    class_name: str
+    output_key: str
+
+
+DEFAULT_COMPONENTS: Mapping[str, ComponentSpec] = {
+    "fractal_engine": ComponentSpec("src.fractal_engine", "FractalEngine", "fractal_output"),
+    "swarm_coordinator": ComponentSpec(
+        "src.swarm_coordinator", "SwarmCoordinator", "swarm_output"
+    ),
+    "quantum_processor": ComponentSpec(
+        "src.quantum_processor", "QuantumProcessor", "quantum_output"
+    ),
+    "meta_learner": ComponentSpec("src.meta_learner", "MetaLearner", "meta_output"),
+}
+
+
+class RFAISystem:
+    """Coordinate the lifecycle of all RFAI components."""
+
+    def __init__(
+        self,
+        config: Optional[MutableMapping[str, Any]] = None,
+        component_factories: Optional[Mapping[str, Callable[[Dict[str, Any]], Any]]] = None,
+    ) -> None:
+        self.config = dict(config or {})
+        self.component_factories = dict(component_factories or {})
+        self.components: Dict[str, Any] = {}
+        self.system_state: Dict[str, Any] = {
+            "cycles": 0,
+            "last_run": None,
+            "last_errors": [],
+        }
+        self.last_outputs: Dict[str, Any] | None = None
+        self._initialise_components()
+
+    def _initialise_components(self) -> None:
+        for name, spec in DEFAULT_COMPONENTS.items():
+            component_cfg = self.config.get(name, {})
+            enabled = bool(component_cfg.get("enabled", True))
+            raw_config = component_cfg.get("config") or {}
+            try:
+                validated_config = validate_component_config(name, raw_config)
+            except (ValidationError, ValueError) as exc:
+                logger.error("Configuration for %s is invalid: %s", name, exc)
+                self.components[name] = None
+                continue
+
+            if not enabled:
+                logger.info("Component %s is disabled via configuration", name)
+                self.components[name] = None
+                continue
+
+            try:
+                factory = self.component_factories.get(name)
+                if factory is not None:
+                    component = factory(validated_config)
+                else:
+                    module = importlib.import_module(spec.module_path)
+                    component_cls = getattr(module, spec.class_name)
+                    component = component_cls(validated_config)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("Failed to load component %s", name)
+                self.components[name] = None
+                continue
+
+            self.components[name] = component
+
+    def _adapter_input(self, component: str, outputs: Dict[str, Any], base_input: Any) -> Any:
+        if component == "fractal_engine":
+            return base_input
+        if component == "swarm_coordinator":
+            return outputs.get("fractal_output")
+        if component == "quantum_processor":
+            return {
+                "fractal_output": outputs.get("fractal_output"),
+                "swarm_output": outputs.get("swarm_output"),
+            }
+        if component == "meta_learner":
+            return {
+                "fractal_output": outputs.get("fractal_output"),
+                "swarm_output": outputs.get("swarm_output"),
+                "quantum_output": outputs.get("quantum_output"),
+            }
+        return base_input
+
+    def run_cycle(self, input_data: Any) -> Dict[str, Any]:
+        """Execute a full inference cycle across all components."""
+
+        outputs: Dict[str, Any] = {
+            "fractal_output": None,
+            "swarm_output": None,
+            "quantum_output": None,
+            "meta_output": None,
+            "errors": [],
+        }
+
+        try:
+            normalised_input = validate_input_payload(input_data)
+        except ValueError as exc:
+            logger.error("Input validation failed: %s", exc)
+            outputs["errors"].append(f"input: {exc}")
+            self._update_state(outputs)
+            return outputs
+
+        for name, spec in DEFAULT_COMPONENTS.items():
+            component = self.components.get(name)
+            if component is None:
+                continue
+            try:
+                adapted_input = self._adapter_input(name, outputs, normalised_input)
+                result = component.process(adapted_input)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Component %s failed during processing", name)
+                outputs["errors"].append(f"{name}: {exc}")
+                outputs[spec.output_key] = None
+                continue
+
+            outputs[spec.output_key] = result
+
+        self._update_state(outputs)
+        return outputs
+
+    def _update_state(self, outputs: Dict[str, Any]) -> None:
+        self.system_state["cycles"] += 1
+        self.system_state["last_run"] = datetime.now(timezone.utc).isoformat()
+        self.system_state["last_errors"] = list(outputs.get("errors", []))
+        self.last_outputs = outputs
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return orchestrator status information."""
+
+        return {
+            "components": {
+                name: self.components.get(name) is not None for name in DEFAULT_COMPONENTS
+            },
+            "cycles": self.system_state["cycles"],
+            "last_run": self.system_state["last_run"],
+            "last_errors": list(self.system_state["last_errors"]),
+        }
+
+
+__all__ = ["RFAISystem"]

--- a/src/swarm_coordinator/__init__.py
+++ b/src/swarm_coordinator/__init__.py
@@ -1,0 +1,5 @@
+"""Swarm coordinator package exposing the `SwarmCoordinator` component."""
+
+from .coordinator import SwarmCoordinator
+
+__all__ = ["SwarmCoordinator"]

--- a/src/swarm_coordinator/coordinator.py
+++ b/src/swarm_coordinator/coordinator.py
@@ -1,0 +1,73 @@
+"""Swarm coordination subsystem."""
+
+from __future__ import annotations
+
+import logging
+from statistics import mean, pstdev
+from typing import Any, Dict, List
+
+from ..utils.validation import SwarmCoordinatorConfig, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class SwarmCoordinator:
+    """Aggregate component results using a virtual swarm of agents."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        try:
+            self.config = SwarmCoordinatorConfig(**(config or {}))
+        except ValidationError as exc:  # pragma: no cover - pydantic validation is exercised elsewhere
+            logger.error("Invalid swarm coordinator configuration: %s", exc)
+            raise ValueError("Invalid swarm coordinator configuration") from exc
+
+    def process(self, fractal_output: Any) -> Dict[str, Any]:
+        """Compute a consensus signal from fractal results."""
+
+        if not isinstance(fractal_output, dict) or "final" not in fractal_output:
+            logger.warning("Swarm coordinator received unexpected input: %s", fractal_output)
+            return {
+                "consensus": None,
+                "agent_votes": [],
+                "confidence": 0.0,
+            }
+
+        signal: List[float] = [float(value) for value in fractal_output["final"]]
+        if not signal:
+            return {
+                "consensus": None,
+                "agent_votes": [],
+                "confidence": 0.0,
+            }
+
+        consensus_value = mean(signal)
+        dispersion = pstdev(signal) if len(signal) > 1 else 0.0
+        agent_votes = [
+            {
+                "agent_id": f"agent-{idx}",
+                "vote": consensus_value + (value - consensus_value) * 0.1,
+                "weight": 1 / self.config.agent_count,
+            }
+            for idx, value in enumerate(signal[: self.config.agent_count])
+        ]
+
+        confidence = max(
+            0.0,
+            min(1.0, self.config.consensus_threshold * (1 - dispersion / (abs(consensus_value) + 1))),
+        )
+
+        logger.debug(
+            "Swarm consensus %.4f with dispersion %.4f and confidence %.2f",
+            consensus_value,
+            dispersion,
+            confidence,
+        )
+
+        return {
+            "consensus": consensus_value,
+            "agent_votes": agent_votes,
+            "confidence": confidence,
+        }
+
+
+__all__ = ["SwarmCoordinator"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,22 @@
+"""Utility helpers for the RFAI system."""
+
+from .state_manager import load_state, save_state
+from .validation import (
+    MetaLearnerConfig,
+    QuantumProcessorConfig,
+    SwarmCoordinatorConfig,
+    FractalEngineConfig,
+    validate_component_config,
+    validate_input_payload,
+)
+
+__all__ = [
+    "load_state",
+    "save_state",
+    "MetaLearnerConfig",
+    "QuantumProcessorConfig",
+    "SwarmCoordinatorConfig",
+    "FractalEngineConfig",
+    "validate_component_config",
+    "validate_input_payload",
+]

--- a/src/utils/state_manager.py
+++ b/src/utils/state_manager.py
@@ -1,0 +1,42 @@
+"""State persistence helpers for the RFAI system."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def save_state(path: str | Path, state: Mapping[str, Any]) -> Path:
+    """Persist orchestration state to disk with an integrity checksum."""
+
+    serialized = json.dumps(state, sort_keys=True, separators=(",", ":"))
+    checksum = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    payload = {"checksum": checksum, "state": state}
+
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return destination
+
+
+def load_state(path: str | Path) -> Mapping[str, Any]:
+    """Load state from disk and verify its checksum."""
+
+    source = Path(path)
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    checksum = payload.get("checksum")
+    state = payload.get("state")
+    if checksum is None or state is None:
+        raise ValueError("State payload is malformed")
+
+    serialized = json.dumps(state, sort_keys=True, separators=(",", ":"))
+    expected = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    if checksum != expected:
+        raise ValueError("Checksum mismatch detected while loading state")
+
+    return state
+
+
+__all__ = ["save_state", "load_state"]

--- a/src/utils/validation.py
+++ b/src/utils/validation.py
@@ -1,0 +1,101 @@
+"""Validation utilities for the RFAI system."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
+
+from pydantic import BaseModel, Field, ValidationError
+
+
+class FractalEngineConfig(BaseModel):
+    """Configuration schema for :class:`FractalEngine` components."""
+
+    max_depth: int = Field(default=3, ge=1, le=32)
+    scale_factor: float = Field(default=0.5, gt=0, le=10)
+    recursion_limit: int = Field(default=8, ge=1, le=64)
+
+
+class SwarmCoordinatorConfig(BaseModel):
+    """Configuration schema for :class:`SwarmCoordinator` components."""
+
+    agent_count: int = Field(default=8, ge=1, le=256)
+    consensus_threshold: float = Field(default=0.75, gt=0, le=1)
+
+
+class QuantumProcessorConfig(BaseModel):
+    """Configuration schema for :class:`QuantumProcessor` components."""
+
+    shots: int = Field(default=128, ge=1, le=4096)
+    decoherence: float = Field(default=0.02, ge=0, le=1)
+
+
+class MetaLearnerConfig(BaseModel):
+    """Configuration schema for :class:`MetaLearner` components."""
+
+    learning_rate: float = Field(default=0.1, gt=0, le=1)
+    momentum: float = Field(default=0.9, ge=0, le=1)
+
+
+CONFIG_MODELS: Mapping[str, type[BaseModel]] = {
+    "fractal_engine": FractalEngineConfig,
+    "swarm_coordinator": SwarmCoordinatorConfig,
+    "quantum_processor": QuantumProcessorConfig,
+    "meta_learner": MetaLearnerConfig,
+}
+
+
+def validate_component_config(name: str, config: Optional[MutableMapping[str, Any]]) -> Dict[str, Any]:
+    """Validate and normalise a component configuration mapping."""
+
+    model = CONFIG_MODELS.get(name)
+    if model is None:
+        return dict(config or {})
+    payload: Dict[str, Any] = dict(config or {})
+    validated = model(**payload)
+    return validated.model_dump()
+
+
+def _coerce_sequence(values: Any) -> Sequence[float]:
+    if isinstance(values, Mapping):
+        for key in ("values", "data", "input"):
+            if key in values:
+                return _coerce_sequence(values[key])
+        raise ValueError("Mapping input must contain a 'values' or 'data' key")
+    if isinstance(values, (bytes, bytearray)):
+        raise ValueError("Binary payloads are not supported")
+    if isinstance(values, str):
+        raise ValueError("String payloads are not supported; provide a numeric sequence")
+    if isinstance(values, (int, float)):
+        return (float(values),)
+    if isinstance(values, Sequence):
+        coerced = []
+        for item in values:
+            if isinstance(item, (int, float)):
+                coerced.append(float(item))
+            else:
+                raise ValueError("Sequence values must be numeric")
+        return tuple(coerced)
+    raise ValueError("Unsupported input payload type")
+
+
+def validate_input_payload(input_data: Any) -> list[float]:
+    """Validate task input payloads, returning a list of floats."""
+
+    values = list(_coerce_sequence(input_data))
+    if not values:
+        raise ValueError("Input payload must contain at least one numeric value")
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("Numeric payload contains non-finite values")
+    return values
+
+
+__all__ = [
+    "FractalEngineConfig",
+    "SwarmCoordinatorConfig",
+    "QuantumProcessorConfig",
+    "MetaLearnerConfig",
+    "validate_component_config",
+    "validate_input_payload",
+    "ValidationError",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration for the RFAI test suite."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_fractal_engine.py
+++ b/tests/test_fractal_engine.py
@@ -1,0 +1,19 @@
+"""Tests for the fractal engine subsystem."""
+
+import pytest
+
+from src.fractal_engine import FractalEngine
+
+
+def test_fractal_engine_respects_recursion_limit() -> None:
+    engine = FractalEngine({"max_depth": 5, "recursion_limit": 2, "scale_factor": 0.5})
+    result = engine.process([1, 2, 3])
+    assert result["iterations"] == 2
+    assert len(result["history"]) == 2
+
+
+@pytest.mark.parametrize("payload", ["invalid", {"values": []}, {"foo": 1}])
+def test_fractal_engine_rejects_invalid_input(payload: object) -> None:
+    engine = FractalEngine()
+    with pytest.raises(ValueError):
+        engine.process(payload)

--- a/tests/test_meta_learner.py
+++ b/tests/test_meta_learner.py
@@ -1,0 +1,29 @@
+"""Tests for the meta learner subsystem."""
+
+import pytest
+
+from src.meta_learner import MetaLearner
+
+
+def test_meta_learner_combines_component_signals() -> None:
+    learner = MetaLearner({"learning_rate": 0.2, "momentum": 0.8})
+    payload = {
+        "fractal_output": {"final": [0.2, 0.4, 0.6]},
+        "swarm_output": {"confidence": 0.7},
+        "quantum_output": {"stability": 0.6},
+    }
+    result = learner.process(payload)
+    assert 0.0 <= result["score"] <= 1.0
+    assert result["recommendations"]
+
+
+def test_meta_learner_handles_missing_inputs() -> None:
+    learner = MetaLearner()
+    result = learner.process({})
+    assert result["score"] == 0.0
+    assert "Collect more data" in result["recommendations"]
+
+
+def test_meta_learner_invalid_config() -> None:
+    with pytest.raises(ValueError):
+        MetaLearner({"learning_rate": 0})

--- a/tests/test_quantum_processor.py
+++ b/tests/test_quantum_processor.py
@@ -1,0 +1,26 @@
+"""Tests for the quantum processor subsystem."""
+
+import pytest
+
+from src.quantum_processor import QuantumProcessor
+
+
+def test_quantum_processor_generates_normalised_state() -> None:
+    processor = QuantumProcessor({"shots": 64, "decoherence": 0.1})
+    result = processor.process({"fractal_output": {"final": [1.0, 0.5, -0.5]}})
+    amplitudes = result["entangled_state"]
+    assert pytest.approx(sum(value * value for value in amplitudes), rel=1e-6) == 1.0
+    assert 0.0 <= result["stability"] <= 1.0
+    assert result["shots"] == 64
+
+
+def test_quantum_processor_handles_missing_signal() -> None:
+    processor = QuantumProcessor()
+    result = processor.process({})
+    assert result["entangled_state"] == []
+    assert result["stability"] == 0.0
+
+
+def test_quantum_processor_invalid_config() -> None:
+    with pytest.raises(ValueError):
+        QuantumProcessor({"shots": 0})

--- a/tests/test_rfai_system_integration.py
+++ b/tests/test_rfai_system_integration.py
@@ -1,0 +1,49 @@
+"""Integration tests for the full RFAI system."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.rfai_system import RFAISystem
+from src.utils.state_manager import load_state, save_state
+
+
+def test_rfai_system_cycle_with_disabled_component() -> None:
+    system = RFAISystem({"quantum_processor": {"enabled": False}})
+    result = system.run_cycle([0.1, 0.2, 0.3])
+    assert set(result) >= {"fractal_output", "swarm_output", "quantum_output", "meta_output", "errors"}
+    assert result["quantum_output"] is None
+    assert result["errors"] == []
+
+
+def test_state_persistence_round_trip(tmp_path: Path) -> None:
+    state = {"cycles": 5, "status": {"ok": True}}
+    path = save_state(tmp_path / "state.json", state)
+    loaded = load_state(path)
+    assert loaded == state
+
+
+def test_api_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_KEY", "secret")
+    api_module = importlib.import_module("src.api")
+    importlib.reload(api_module)
+    client = TestClient(api_module.app)
+
+    health = client.get("/health")
+    assert health.status_code == 200
+    assert health.json()["status"] == "ok"
+
+    response = client.post(
+        "/process_task",
+        json={"values": [1, 2, 3]},
+        headers={"X-API-Key": "secret"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data) >= {"fractal_output", "swarm_output", "quantum_output", "meta_output", "errors"}
+
+    status_response = client.get("/status", headers={"X-API-Key": "secret"})
+    assert status_response.status_code == 200
+    assert "components" in status_response.json()

--- a/tests/test_swarm_coordinator.py
+++ b/tests/test_swarm_coordinator.py
@@ -1,0 +1,25 @@
+"""Tests for the swarm coordinator subsystem."""
+
+import pytest
+
+from src.swarm_coordinator import SwarmCoordinator
+
+
+def test_swarm_coordinator_builds_consensus() -> None:
+    coordinator = SwarmCoordinator({"agent_count": 3, "consensus_threshold": 0.8})
+    result = coordinator.process({"final": [1.0, 2.0, 3.0]})
+    assert result["consensus"] == pytest.approx(2.0)
+    assert len(result["agent_votes"]) == 3
+    assert 0 <= result["confidence"] <= 1
+
+
+def test_swarm_coordinator_handles_unexpected_payload() -> None:
+    coordinator = SwarmCoordinator()
+    result = coordinator.process("not-a-dict")
+    assert result["consensus"] is None
+    assert result["confidence"] == 0.0
+
+
+def test_swarm_coordinator_invalid_config() -> None:
+    with pytest.raises(ValueError):
+        SwarmCoordinator({"agent_count": 0})


### PR DESCRIPTION
## Summary
- create a modular RFAI orchestrator with dynamic component loading, validation, and FastAPI surface
- implement subsystem stubs, utilities, tests, and deployment tooling
- add developer documentation, CI workflow, and containerisation assets

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4a1d135008326981cf3a779b6afec